### PR TITLE
Fixed hang on startup

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ fi
 # Ensure that an SSH key exists
 if [ ! -e /var/lib/backuppc/.ssh/id_rsa ] ; then
     mkdir /var/lib/backuppc/.ssh
-    ssh-keygen -f /var/lib/backuppc/.ssh/id_rsa -C "BackupPC Backup Key"
+    ssh-keygen -f /var/lib/backuppc/.ssh/id_rsa -N '' -C "BackupPC Backup Key"
     cp /etc/backuppc-ssh-config /var/lib/backuppc/.ssh/config
     chown -R backuppc:backuppc /var/lib/backuppc/.ssh
     echo 


### PR DESCRIPTION
Added -N '' to default to an empty password, otherwise the container hangs on startup waiting for the user to enter a password.